### PR TITLE
[DEV] 메인페이지, 일기 상세 페이지 구현

### DIFF
--- a/Junghyun/react-ts/src/app/detail/[id]/page.tsx
+++ b/Junghyun/react-ts/src/app/detail/[id]/page.tsx
@@ -6,5 +6,23 @@ type DiaryDetailPageParams = {
 
 export default function DiaryDetailPage() {
     const { id } = useParams<DiaryDetailPageParams>()
-    return <>Diary details {id}</>
+
+    return (
+        <div className="flex flex-col h-full w-1/2 justify-center gap-10">
+            <div className="flex flex-col gap-4">
+                <h1 className="text-4xl">제목</h1>
+                <div className="flex flex-row gap-2">
+                    <button className="gray-btn flex-1">날짜</button>
+                    <button className="gray-btn flex-1">날씨</button>
+                    <button className="gray-btn flex-1">감정</button>
+                </div>
+            </div>
+
+            <div className="flex h-1/2 text-xl">일기 내용</div>
+            <div className="flex flex-row gap-2">
+                <button className="green-btn flex-1 p-2">새로운 일기 작성하기</button>
+                <button className="red-btn flex-1 p-2">현재 일기 삭제하기</button>
+            </div>
+        </div>
+    )
 }

--- a/Junghyun/react-ts/src/app/detail/[id]/page.tsx
+++ b/Junghyun/react-ts/src/app/detail/[id]/page.tsx
@@ -1,4 +1,5 @@
 import { useParams } from 'react-router-dom'
+import { useDiaryValue } from '../../../provider/Diary'
 
 type DiaryDetailPageParams = {
     id: string
@@ -6,19 +7,26 @@ type DiaryDetailPageParams = {
 
 export default function DiaryDetailPage() {
     const { id } = useParams<DiaryDetailPageParams>()
+    const diary = useDiaryValue().find((diary) => diary.id === id)
+    const formattedDate = new Date(diary!.date).toLocaleDateString('ko-KR', {
+        year: 'numeric',
+        month: 'long',
+        day: 'numeric',
+        weekday: 'long',
+    })
 
     return (
         <div className="flex flex-col h-full w-1/2 justify-center gap-10">
             <div className="flex flex-col gap-4">
-                <h1 className="text-4xl">제목</h1>
+                <h1 className="text-4xl">{diary!.title}</h1>
                 <div className="flex flex-row gap-2">
-                    <button className="gray-btn flex-1">날짜</button>
-                    <button className="gray-btn flex-1">날씨</button>
-                    <button className="gray-btn flex-1">감정</button>
+                    <button className="gray-btn flex-1">{formattedDate}</button>
+                    <button className="gray-btn flex-1">{diary!.weather}</button>
+                    <button className="gray-btn flex-1">{diary!.emotion}</button>
                 </div>
             </div>
 
-            <div className="flex h-1/2 text-xl">일기 내용</div>
+            <div className="flex h-1/2 text-xl">{diary!.content}</div>
             <div className="flex flex-row gap-2">
                 <button className="green-btn flex-1 p-2">새로운 일기 작성하기</button>
                 <button className="red-btn flex-1 p-2">현재 일기 삭제하기</button>

--- a/Junghyun/react-ts/src/app/page.tsx
+++ b/Junghyun/react-ts/src/app/page.tsx
@@ -111,15 +111,20 @@ const DiaryWriter = () => {
 
 const DiaryViewer = () => {
     const diaries = useDiaryValue()
+    const isDiaryExist = diaries.length > 0
 
     return (
         <div className="flex flex-col gap-4 p-4 justify-between h-2/3 w-full border border-gray-200 rounded-lg">
             <h1 className="text-xl text-green-600 mt-4">기록된 일기</h1>
-            <div className="flex flex-col gap-2 overflow-y-auto">
-                {diaries.map((diaries) => (
-                    <DiaryCard key={diaries.id} {...diaries} />
-                ))}
-            </div>
+            {isDiaryExist ? (
+                <div className="flex flex-col gap-2 overflow-y-auto">
+                    {diaries.map((diaries) => (
+                        <DiaryCard key={diaries.id} {...diaries} />
+                    ))}
+                </div>
+            ) : (
+                <h1 className="flex items-center justify-start text-gray-400">일기를 적어보세요</h1>
+            )}
 
             <button className="green-btn p-2">감정 모아 보기</button>
         </div>

--- a/Junghyun/react-ts/src/app/page.tsx
+++ b/Junghyun/react-ts/src/app/page.tsx
@@ -5,8 +5,8 @@ import DiaryCard from '../components/DiaryCard'
 const DiaryWriter = () => {
     const [title, setTitle] = useState<string>('')
     const [content, setContent] = useState<string>('')
-    const [emotion, setEmotion] = useState<Diary['emotion']>()
-    const [weather, setWeather] = useState<Diary['weather']>()
+    const [emotion, setEmotion] = useState<Diary['emotion'] | undefined>()
+    const [weather, setWeather] = useState<Diary['weather'] | undefined>()
     const [isValid, setIsValid] = useState<boolean>(false)
 
     useEffect(() => {
@@ -37,12 +37,8 @@ const DiaryWriter = () => {
                             <button
                                 key={emotionType}
                                 onClick={() => setEmotion(emotionType)}
-                                className={`border border-transparent p-1 rounded-lg
-                                    ${
-                                        emotion === emotionType
-                                            ? 'bg-green-200 text-green-600 hover:border-green-600'
-                                            : 'bg-gray-200  text-gray-500 hover:border-gray-600 hover:text-gray-600'
-                                    }
+                                className={`p-1
+                                    ${emotion === emotionType ? 'green-btn' : 'gray-btn'}
                                 `}
                             >
                                 {emotionType}
@@ -54,12 +50,8 @@ const DiaryWriter = () => {
                             <button
                                 key={weatherType}
                                 onClick={() => setWeather(weatherType)}
-                                className={`border border-transparent p-1 rounded-lg
-                                ${
-                                    weather === weatherType
-                                        ? 'bg-blue-200 text-blue-600 hover:border-blue-600'
-                                        : 'bg-gray-200  text-gray-500 hover:border-gray-600 hover:text-gray-600'
-                                }
+                                className={`p-1
+                                ${weather === weatherType ? 'blue-btn' : 'gray-btn'}
                             `}
                             >
                                 {weatherType}
@@ -75,8 +67,8 @@ const DiaryWriter = () => {
                     placeholder="오늘 당신의 하루는 어땠나요?"
                 />
                 <button
-                    className={`p-2 rounded-lg
-                    ${isValid ? 'bg-green-200 text-green-600' : 'bg-gray-200 text-gray-500'}`}
+                    className={`p-2
+                    ${isValid ? 'green-btn' : 'gray-btn'}`}
                 >
                     {isValid ? '일기를 저장해 보아요' : '일기를 더 자세히 적어볼까요?'}
                 </button>
@@ -93,7 +85,7 @@ export default function DiaryHomePage() {
                 <h1 className="text-xl text-green-600 mt-4">기록된 일기</h1>
                 {/* <div className="text-gray-400">일기를 적어보세요</div> */}
                 <DiaryCard />
-                <button className="bg-green-100 p-2 rounded-lg text-green-600">감정 모아 보기</button>
+                <button className="green-btn p-2">감정 모아 보기</button>
             </div>
         </div>
     )

--- a/Junghyun/react-ts/src/app/page.tsx
+++ b/Junghyun/react-ts/src/app/page.tsx
@@ -10,7 +10,7 @@ const DiaryWriter = () => {
     const [isValid, setIsValid] = useState<boolean>(false)
 
     useEffect(() => {
-        const isInvalid = title.length < 1 || content.length < 3 || !emotion || !weather
+        const isInvalid = title.length < 3 || content.length < 6 || !emotion || !weather
         setIsValid(!isInvalid)
     }, [title, content, emotion, weather])
 
@@ -25,8 +25,7 @@ const DiaryWriter = () => {
         <>
             <div className="flex flex-col gap-4 p-4 justify-between h-2/3 w-full border border-gray-200 rounded-lg">
                 <input
-                    className="rounded-lg p-2 text-2xl mt-4
-                    focus:outline-none focus:ring-1 focus:ring-gray-200"
+                    className="text-2xl mt-4 input-box"
                     value={title}
                     onChange={handleTitleChange}
                     placeholder="제목을 적어보세요"
@@ -60,8 +59,7 @@ const DiaryWriter = () => {
                     </div>
                 </div>
                 <textarea
-                    className="rounded-lg p-2 h-1/2 text-m
-                    focus:outline-none focus:ring-1 focus:ring-gray-200"
+                    className="h-1/2 text-m input-box"
                     value={content}
                     onChange={handleContentChange}
                     placeholder="오늘 당신의 하루는 어땠나요?"

--- a/Junghyun/react-ts/src/app/page.tsx
+++ b/Junghyun/react-ts/src/app/page.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react'
 import { Diary } from '../interface/diary'
 import DiaryCard from '../components/DiaryCard'
+import { useDiaryValue, useDiaryUpdate } from '../provider/Diary'
 
 const DiaryWriter = () => {
     const [title, setTitle] = useState<string>('')
@@ -8,6 +9,7 @@ const DiaryWriter = () => {
     const [emotion, setEmotion] = useState<Diary['emotion'] | undefined>()
     const [weather, setWeather] = useState<Diary['weather'] | undefined>()
     const [isValid, setIsValid] = useState<boolean>(false)
+    const updateDiaries = useDiaryUpdate()
 
     useEffect(() => {
         const isInvalid = title.length < 2 || content.length < 6 || !emotion || !weather
@@ -38,7 +40,7 @@ const DiaryWriter = () => {
             const savedDiaries: Diary[] = JSON.parse(localStorage.getItem('diaries') || '[]')
 
             localStorage.setItem('diaries', JSON.stringify([...savedDiaries, newDiary]))
-            console.log(newDiary)
+            updateDiaries((prev) => [...prev, newDiary])
 
             setTitle('')
             setContent('')
@@ -98,7 +100,7 @@ const DiaryWriter = () => {
                 <button
                     className={`p-2
                     ${isValid ? 'green-btn' : 'gray-btn'}`}
-
+                    onClick={handleSaveDiary}
                 >
                     {isValid ? '일기를 저장해 보아요' : '일기를 더 자세히 적어볼까요?'}
                 </button>
@@ -106,17 +108,29 @@ const DiaryWriter = () => {
         </>
     )
 }
+
+const DiaryViewer = () => {
+    const diaries = useDiaryValue()
+
+    return (
+        <div className="flex flex-col gap-4 p-4 justify-between h-2/3 w-full border border-gray-200 rounded-lg">
+            <h1 className="text-xl text-green-600 mt-4">기록된 일기</h1>
+            <div className="flex flex-col gap-2 overflow-y-auto">
+                {diaries.map((diaries) => (
+                    <DiaryCard key={diaries.id} {...diaries} />
+                ))}
+            </div>
+
+            <button className="green-btn p-2">감정 모아 보기</button>
+        </div>
+    )
+}
+
 export default function DiaryHomePage() {
     return (
         <div className="flex flex-col items-center justify-center h-full gap-10 md:grid md:grid-rows-1 md:grid-cols-[3fr,2fr] md:w-4/5 lg:w-2/3">
             <DiaryWriter />
-
-            <div className="flex flex-col gap-4 p-4 justify-between h-2/3 w-full border border-gray-200 rounded-lg">
-                <h1 className="text-xl text-green-600 mt-4">기록된 일기</h1>
-                {/* <div className="text-gray-400">일기를 적어보세요</div> */}
-                <DiaryCard />
-                <button className="green-btn p-2">감정 모아 보기</button>
-            </div>
+            <DiaryViewer />
         </div>
     )
 }

--- a/Junghyun/react-ts/src/app/page.tsx
+++ b/Junghyun/react-ts/src/app/page.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react'
 import { Diary } from '../interface/diary'
 import DiaryCard from '../components/DiaryCard'
 import { useDiaryValue, useDiaryUpdate } from '../provider/Diary'
+import { Link } from 'react-router-dom'
 
 const DiaryWriter = () => {
     const [title, setTitle] = useState<string>('')
@@ -126,7 +127,9 @@ const DiaryViewer = () => {
                 <h1 className="flex items-center justify-start text-gray-400">일기를 적어보세요</h1>
             )}
 
-            <button className="green-btn p-2">감정 모아 보기</button>
+            <Link to={`/emotions`} className="green-btn p-2 flex justify-center items-center">
+                감정 모아 보기
+            </Link>
         </div>
     )
 }

--- a/Junghyun/react-ts/src/app/page.tsx
+++ b/Junghyun/react-ts/src/app/page.tsx
@@ -10,7 +10,7 @@ const DiaryWriter = () => {
     const [isValid, setIsValid] = useState<boolean>(false)
 
     useEffect(() => {
-        const isInvalid = title.length < 1 || content.length < 3 || !emotion || !weather
+        const isInvalid = title.length < 2 || content.length < 6 || !emotion || !weather
         setIsValid(!isInvalid)
     }, [title, content, emotion, weather])
 
@@ -19,6 +19,36 @@ const DiaryWriter = () => {
     }
     const handleContentChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
         setContent(e.target.value)
+    }
+    const handleSaveDiary = () => {
+        if (!isValid) return
+
+        const newDiary: Diary = {
+            id: crypto.randomUUID(),
+            date: new Date(),
+            title,
+            content,
+            emotion: emotion!,
+            weather: weather!,
+            views: 1,
+        }
+
+        try {
+            const savedDiaries: Diary[] = JSON.parse(localStorage.getItem('diaries') || '[]')
+
+            localStorage.setItem('diaries', JSON.stringify([...savedDiaries, newDiary]))
+            console.log(newDiary)
+
+            setTitle('')
+            setContent('')
+            setEmotion(undefined)
+            setWeather(undefined)
+
+            console.log('일기 저장 성공')
+        } catch (error) {
+            console.error('일기 저장 실패', error)
+            alert('일기 저장 실패. 다시 시도 하십시오.')
+        }
     }
 
     return (
@@ -77,6 +107,7 @@ const DiaryWriter = () => {
                 <button
                     className={`p-2 rounded-lg
                     ${isValid ? 'bg-green-200 text-green-600' : 'bg-gray-200 text-gray-500'}`}
+                    onClick={handleSaveDiary}
                 >
                     {isValid ? '일기를 저장해 보아요' : '일기를 더 자세히 적어볼까요?'}
                 </button>

--- a/Junghyun/react-ts/src/components/DiaryCard.tsx
+++ b/Junghyun/react-ts/src/components/DiaryCard.tsx
@@ -3,7 +3,7 @@ import { Link } from 'react-router-dom'
 
 export default function DiaryCard({ title, date, emotion, weather, id }: Diary) {
     const formattedDate = new Date(date)
-        .toLocaleDateString('ko-KR', { year: 'numeric', month: '2-digit', day: '2-digit', formatMatcher: 'basic' })
+        .toLocaleDateString('ko-KR', { year: 'numeric', month: 'numeric', day: 'numeric', formatMatcher: 'basic' })
         .replace(/\//g, '.')
 
     const emotionEmoji = {

--- a/Junghyun/react-ts/src/components/DiaryCard.tsx
+++ b/Junghyun/react-ts/src/components/DiaryCard.tsx
@@ -22,7 +22,7 @@ export default function DiaryCard({ title, date, emotion, weather, id }: Diary) 
     }
     return (
         <Link
-            to={`/diary/${id}`}
+            to={`/detail/${id}`}
             className="flex flex-col gap-2 w-full p-3 border border-gray-200 rounded-lg items-start justify-center"
         >
             <h1 className="text-grey-600">{title}</h1>

--- a/Junghyun/react-ts/src/components/DiaryCard.tsx
+++ b/Junghyun/react-ts/src/components/DiaryCard.tsx
@@ -1,7 +1,10 @@
 import { Diary } from '../interface/diary'
+import { Link } from 'react-router-dom'
 
 export default function DiaryCard({ title, date, emotion, weather, id }: Diary) {
-    const formattedDate = date.toLocaleDateString('ko-KR', { year: 'numeric', month: 'long', day: 'numeric' })
+    const formattedDate = new Date(date)
+        .toLocaleDateString('ko-KR', { year: 'numeric', month: '2-digit', day: '2-digit', formatMatcher: 'basic' })
+        .replace(/\//g, '.')
 
     const emotionEmoji = {
         bad: '🤬',
@@ -18,7 +21,10 @@ export default function DiaryCard({ title, date, emotion, weather, id }: Diary) 
         snow: '❄️',
     }
     return (
-        <div className="flex flex-col gap-2 w-full p-3 border border-gray-200 rounded-lg items-start justify-center">
+        <Link
+            to={`/diary/${id}`}
+            className="flex flex-col gap-2 w-full p-3 border border-gray-200 rounded-lg items-start justify-center"
+        >
             <h1 className="text-grey-600">{title}</h1>
             <div className="flex flex-row justify-between w-full">
                 <span className="text-gray-400">{formattedDate}</span>
@@ -31,6 +37,6 @@ export default function DiaryCard({ title, date, emotion, weather, id }: Diary) 
                     </div>
                 </div>
             </div>
-        </div>
+        </Link>
     )
 }

--- a/Junghyun/react-ts/src/components/DiaryCard.tsx
+++ b/Junghyun/react-ts/src/components/DiaryCard.tsx
@@ -2,9 +2,12 @@ import { Diary } from '../interface/diary'
 import { Link } from 'react-router-dom'
 
 export default function DiaryCard({ title, date, emotion, weather, id }: Diary) {
-    const formattedDate = new Date(date)
-        .toLocaleDateString('ko-KR', { year: 'numeric', month: 'numeric', day: 'numeric', formatMatcher: 'basic' })
-        .replace(/\//g, '.')
+    const formattedDate = new Date(date).toLocaleDateString('ko-KR', {
+        year: 'numeric',
+        month: 'numeric',
+        day: 'numeric',
+        formatMatcher: 'basic',
+    })
 
     const emotionEmoji = {
         bad: '🤬',

--- a/Junghyun/react-ts/src/components/DiaryCard.tsx
+++ b/Junghyun/react-ts/src/components/DiaryCard.tsx
@@ -1,15 +1,33 @@
-export default function DiaryCard() {
+import { Diary } from '../interface/diary'
+
+export default function DiaryCard({ title, date, emotion, weather, id }: Diary) {
+    const formattedDate = date.toLocaleDateString('ko-KR', { year: 'numeric', month: 'long', day: 'numeric' })
+
+    const emotionEmoji = {
+        bad: '🤬',
+        soso: '😙',
+        good: '😊',
+        great: '😃',
+        awesome: '😎',
+    }
+
+    const weatherEmoji = {
+        sunny: '☀️',
+        cloud: '☁️',
+        rain: '🌧️',
+        snow: '❄️',
+    }
     return (
         <div className="flex flex-col gap-2 w-full p-3 border border-gray-200 rounded-lg items-start justify-center">
-            <h1 className="text-grey-600">제목</h1>
+            <h1 className="text-grey-600">{title}</h1>
             <div className="flex flex-row justify-between w-full">
-                <span className="text-gray-400">2025.1.1</span>
+                <span className="text-gray-400">{formattedDate}</span>
                 <div className="flex flex-row">
                     <div className="flex items-center justify-center border border-gray-200 rounded-full p-1 w-6 h-6">
-                        😊
+                        {emotionEmoji[emotion]}
                     </div>
                     <div className="flex items-center justify-center border border-gray-200 rounded-full p-1 w-6 h-6">
-                        🌧️
+                        {weatherEmoji[weather]}
                     </div>
                 </div>
             </div>

--- a/Junghyun/react-ts/src/provider/Diary.tsx
+++ b/Junghyun/react-ts/src/provider/Diary.tsx
@@ -1,4 +1,4 @@
-import { createContext, useContext, useState } from 'react'
+import { createContext, useContext, useState, useEffect } from 'react'
 import { Diary } from '../interface/diary'
 
 const DiaryValueContext = createContext<Diary[] | undefined>(undefined)
@@ -7,6 +7,17 @@ const DiaryUpdateContext = createContext<DiaryUpdate | undefined>(undefined)
 
 const DiaryProvider = ({ children }: React.PropsWithChildren) => {
     const [diaries, updateDiaries] = useState<Diary[]>([])
+
+    useEffect(() => {
+        try {
+            const savedDiaries: Diary[] = JSON.parse(localStorage.getItem('diaries') || '[]')
+            updateDiaries(savedDiaries)
+        } catch (error) {
+            console.error('일기 데이터 불러오기 실패', error)
+            updateDiaries([])
+        }
+    }, [])
+
     return (
         <DiaryValueContext.Provider value={diaries}>
             <DiaryUpdateContext.Provider value={updateDiaries}>{children}</DiaryUpdateContext.Provider>

--- a/Junghyun/react-ts/src/tailwind.css
+++ b/Junghyun/react-ts/src/tailwind.css
@@ -12,4 +12,7 @@
     .blue-btn {
         @apply rounded-lg border border-transparent bg-blue-100 text-blue-600 hover:border-blue-600;
     }
+    .input-box {
+        @apply rounded-lg p-2 focus:outline-none focus:ring-1 focus:ring-gray-200;
+    }
 }

--- a/Junghyun/react-ts/src/tailwind.css
+++ b/Junghyun/react-ts/src/tailwind.css
@@ -12,6 +12,9 @@
     .blue-btn {
         @apply rounded-lg border border-transparent bg-blue-100 text-blue-600 hover:border-blue-600;
     }
+    .red-btn {
+        @apply rounded-lg border border-transparent bg-red-100 text-red-600 hover:border-red-600;
+    }
     .input-box {
         @apply rounded-lg p-2 focus:outline-none focus:ring-1 focus:ring-gray-200;
     }

--- a/Junghyun/react-ts/src/tailwind.css
+++ b/Junghyun/react-ts/src/tailwind.css
@@ -1,3 +1,15 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+@layer components {
+    .gray-btn {
+        @apply rounded-lg border border-transparent bg-gray-200 text-gray-500 hover:border-gray-600 hover:text-gray-600;
+    }
+    .green-btn {
+        @apply rounded-lg border border-transparent bg-green-100 text-green-600 hover:border-green-600;
+    }
+    .blue-btn {
+        @apply rounded-lg border border-transparent bg-blue-100 text-blue-600 hover:border-blue-600;
+    }
+}


### PR DESCRIPTION
## Summary

메인페이지의 모든 기능을 구현 완료 했습니다.
일기 상세 페이지의 일부를 구현했습니다.

## Description

- 일기 작성 후 저장
- 저장된 일기 보기
- 일기 카드, 감정 모아보기 링크 연결
<img width="829" alt="스크린샷 2025-01-25 오전 12 05 43" src="https://github.com/user-attachments/assets/ef258883-ae9d-40e2-9057-586555d91da4" />

- 상세 페이지 UI 구현
- 실제 일기 데이터 연결
<img width="680" alt="스크린샷 2025-01-25 오전 1 14 55" src="https://github.com/user-attachments/assets/43e508ab-43f1-4158-aec1-552669fc6ccd" />

