### PR TITLE
[DEV] 상세 페이지 구현

### DIFF
--- a/Yewon/react-ts/src/app/detail/[id]/page.tsx
+++ b/Yewon/react-ts/src/app/detail/[id]/page.tsx
@@ -1,4 +1,4 @@
-import { useParams } from 'react-router-dom'
+import { Link, useParams } from 'react-router-dom'
 import { Diary } from '../../../interface/diary'
 import { DIARYKEY } from '../../../app/page'
 import { useEffect, useState } from 'react'
@@ -39,6 +39,12 @@ export default function DiaryDetailPage() {
             </div>
 
             <div className="text-base text-gray-800 h-2/3">{diary?.content}</div>
+
+            <div className="w-full flex flex-row gap-2">
+                <Link to="/" className="w-full">
+                    <button className="green-btn w-full p-2">새로운 일기 작성하기</button>
+                </Link>
+            </div>
         </div>
     )
 }

--- a/Yewon/react-ts/src/app/detail/[id]/page.tsx
+++ b/Yewon/react-ts/src/app/detail/[id]/page.tsx
@@ -12,16 +12,27 @@ export default function DiaryDetailPage() {
     const storedData: Diary[] = JSON.parse(localStorage.getItem(DIARYKEY)!) || []
     const [diary, setDiary] = useState<Diary | undefined>()
 
+    const formatDate = (date: Date): string => {
+        const strDate = date.toString()
+
+        const year = strDate.substring(0, 4)
+        const month = strDate.substring(5, 7)
+        const day = strDate.substring(8, 10)
+        return `${year}년 ${month}월 ${day}일`
+    } //DiaryCard의 formatData와 합치기
+
     useEffect(() => {
         setDiary(storedData.find((item) => item.id === id))
-    }, [id])
+    }, [])
 
     return (
         <div className="w-2/4 h-full py-20">
             <div className="flex flex-col gap-4 my-9">
                 <h1 className="text-4xl font-medium">{diary?.title}</h1>
                 <div className="flex flex-row gap-2">
-                    <button className="grow default-btn">2025년 1월 25일</button>
+                    <button className="grow default-btn">
+                        {diary?.date ? formatDate(diary.date) : '날짜를 불러올 수 없습니다.'}
+                    </button>
                     <button className="grow default-btn">{diary?.weather}</button>
                     <button className="grow default-btn">{diary?.emotion}</button>
                 </div>

--- a/Yewon/react-ts/src/app/detail/[id]/page.tsx
+++ b/Yewon/react-ts/src/app/detail/[id]/page.tsx
@@ -1,4 +1,7 @@
 import { useParams } from 'react-router-dom'
+import { Diary } from '../../../interface/diary'
+import { DIARYKEY } from '../../../app/page'
+import { useEffect, useState } from 'react'
 
 type DiaryDetailPageParams = {
     id: string
@@ -6,5 +9,25 @@ type DiaryDetailPageParams = {
 
 export default function DiaryDetailPage() {
     const { id } = useParams<DiaryDetailPageParams>()
-    return <>Diary details {id}</>
+    const storedData: Diary[] = JSON.parse(localStorage.getItem(DIARYKEY)!) || []
+    const [diary, setDiary] = useState<Diary | undefined>()
+
+    useEffect(() => {
+        setDiary(storedData.find((item) => item.id === id))
+    }, [id])
+
+    return (
+        <div className="w-2/4 h-full py-20">
+            <div className="flex flex-col gap-4 my-9">
+                <h1 className="text-4xl font-medium">{diary?.title}</h1>
+                <div className="flex flex-row gap-2">
+                    <button className="grow default-btn">2025년 1월 25일</button>
+                    <button className="grow default-btn">{diary?.weather}</button>
+                    <button className="grow default-btn">{diary?.emotion}</button>
+                </div>
+            </div>
+
+            <div className="text-base text-gray-800 h-2/3">{diary?.content}</div>
+        </div>
+    )
 }

--- a/Yewon/react-ts/src/app/detail/[id]/page.tsx
+++ b/Yewon/react-ts/src/app/detail/[id]/page.tsx
@@ -44,6 +44,9 @@ export default function DiaryDetailPage() {
                 <Link to="/" className="w-full">
                     <button className="green-btn w-full p-2">새로운 일기 작성하기</button>
                 </Link>
+                <Link to="/" className="w-full">
+                    <button className="red-btn w-full p-2">현재 일기 삭제하기</button>
+                </Link>
             </div>
         </div>
     )

--- a/Yewon/react-ts/src/app/detail/[id]/page.tsx
+++ b/Yewon/react-ts/src/app/detail/[id]/page.tsx
@@ -2,6 +2,7 @@ import { Link, useParams } from 'react-router-dom'
 import { Diary } from '../../../interface/diary'
 import { DIARYKEY } from '../../../app/page'
 import { useEffect, useState } from 'react'
+import { formatDate } from '../../../util/dateUtil'
 
 type DiaryDetailPageParams = {
     id: string
@@ -11,15 +12,6 @@ export default function DiaryDetailPage() {
     const { id } = useParams<DiaryDetailPageParams>()
     const storedData: Diary[] = JSON.parse(localStorage.getItem(DIARYKEY)!) || []
     const [diary, setDiary] = useState<Diary | undefined>()
-
-    const formatDate = (date: Date): string => {
-        const strDate = date.toString()
-
-        const year = strDate.substring(0, 4)
-        const month = strDate.substring(5, 7)
-        const day = strDate.substring(8, 10)
-        return `${year}년 ${month}월 ${day}일`
-    } //DiaryCard의 formatData와 합치기
 
     const deleteDiary = () => {
         localStorage.setItem(DIARYKEY, JSON.stringify(storedData.filter((user) => user.id !== id)))

--- a/Yewon/react-ts/src/app/detail/[id]/page.tsx
+++ b/Yewon/react-ts/src/app/detail/[id]/page.tsx
@@ -21,6 +21,10 @@ export default function DiaryDetailPage() {
         return `${year}년 ${month}월 ${day}일`
     } //DiaryCard의 formatData와 합치기
 
+    const deleteDiary = () => {
+        localStorage.setItem(DIARYKEY, JSON.stringify(storedData.filter((user) => user.id !== id)))
+    }
+
     useEffect(() => {
         setDiary(storedData.find((item) => item.id === id))
     }, [])
@@ -45,7 +49,9 @@ export default function DiaryDetailPage() {
                     <button className="green-btn w-full p-2">새로운 일기 작성하기</button>
                 </Link>
                 <Link to="/" className="w-full">
-                    <button className="red-btn w-full p-2">현재 일기 삭제하기</button>
+                    <button className="red-btn w-full p-2" onClick={() => deleteDiary()}>
+                        현재 일기 삭제하기
+                    </button>
                 </Link>
             </div>
         </div>

--- a/Yewon/react-ts/src/app/page.tsx
+++ b/Yewon/react-ts/src/app/page.tsx
@@ -26,8 +26,6 @@ function saveDiary(title: string, contents: string, selectedEmotion: Emotion, se
     localStorage.setItem(DIARYKEY, JSON.stringify([...storedData, newDiaryObj]))
 }
 
-
-
 const DiaryWriter = () => {
     const [title, setTitle] = useState('')
     const [contents, setContents] = useState('')

--- a/Yewon/react-ts/src/components/DiaryCard.tsx
+++ b/Yewon/react-ts/src/components/DiaryCard.tsx
@@ -2,21 +2,13 @@ import { Diary } from '../interface/diary'
 import { Link } from 'react-router-dom'
 import { EmotionIcon } from './EmotionIcon'
 import { WeatherIcon } from './WeatherIcon'
+import { formatDate } from '../util/dateUtil'
 
 interface DiaryProps {
     diary: Diary
 }
 
 export const DiaryCard: React.FC<DiaryProps> = ({ diary }) => {
-    const formatDate = (date: Date): string => {
-        const strDate = date.toString()
-
-        const year = strDate.substring(0, 4)
-        const month = strDate.substring(5, 7)
-        const day = strDate.substring(8, 10)
-        return `${year}. ${month}. ${day}.`
-    }
-
     return (
         <Link to={`detail/${diary.id}`} key={diary.id}>
             <button className="w-full flex flex-col items-start justify-center gap-1.5 p-3 hover:bg-gray-50 border border-gray-100 rounded-lg">

--- a/Yewon/react-ts/src/tailwind.css
+++ b/Yewon/react-ts/src/tailwind.css
@@ -18,4 +18,8 @@
   .blue-btn {
     @apply p-1 rounded-lg text-sm border border-transparent bg-blue-100 text-blue-600 hover:border-blue-600
   }
+
+  .red-btn {
+    @apply p-1 rounded-lg text-sm border border-transparent bg-red-100 text-red-600 hover:border-red-600
+  }
 }

--- a/Yewon/react-ts/src/util/dateUtil.ts
+++ b/Yewon/react-ts/src/util/dateUtil.ts
@@ -1,0 +1,12 @@
+export const formatDate = (rawDate: Date): string => {
+    if (!rawDate) return "유효하지 않은 날짜";
+
+    const date = rawDate instanceof Date ? rawDate : new Date(rawDate);
+    if (isNaN(date.getTime())) return "유효하지 않은 날짜";
+
+    return date.toLocaleDateString("ko-KR", {
+        year: "numeric",
+        month: "long",
+        day: "numeric",
+    });
+} 


### PR DESCRIPTION
## Summary

상세 페이지 구현을 완료하였습니다.

## Description

![image](https://github.com/user-attachments/assets/bf19d1b0-6c1d-47bd-b6f5-a4236df560fc)

- param으로 넘겨 받은 id와 localStroage에 저장된 일기들의 id를 비교하여 찾아낸 일기의 상세 정보를 나타냅니다.
- '새로운 일기 작성하기' 버튼을 누르면 메인 페이지로 이동합니다.
- '현재 일기 삭제하기' 버튼을 누르면 localStoage에서 이 일기를 삭제하고 메인 페이지로 이동합니다. 
- util 폴더를 생성하여 공통되는 날짜 처리 함수를 분리하였습니다.

<br/>